### PR TITLE
fix: Remove xunit-runner dependency

### DIFF
--- a/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove xunit runner tool due to deprecation, as noted https://xunit.github.io/releases/2.4. This dependency was also periodically causing the
builds to fail in codebuild.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
