### PR TITLE
Allows the Parameter Name Prefix To Be Retrieved From Configuration

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
@@ -28,5 +28,8 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         /// don't specify a key ID, the system uses the default key associated with your AWS account.
         /// </summary>
         public string KMSKeyId { get; set; }
+
+        /// <summary>The prefix applied to the DataProtection key names.</summary>
+        public string ParameterNamePrefix { get; set; }
     }
 }

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
@@ -64,6 +64,21 @@ namespace Amazon.AspNetCore.DataProtection.SSM.Tests
             AssertDataProtectUnprotect(serviceContainer.BuildServiceProvider());
         }
 
+        [Fact]
+        public void RegisterSSMProviderFromOptions()
+        {
+            var ssmClient = CreateMockSSMClient(null);
+
+            var serviceContainer = new ServiceCollection()
+                    .AddSingleton<IAmazonSimpleSystemsManagement>(ssmClient)
+                    .Configure<PersistOptions>(o => o.ParameterNamePrefix = "/RegisterTest");
+
+            serviceContainer.AddDataProtection()
+                .PersistKeysToAWSSystemsManager();
+
+            AssertDataProtectUnprotect(serviceContainer.BuildServiceProvider());
+        }
+
         private IAmazonSimpleSystemsManagement CreateMockSSMClient(string kmsKeyId)
         {
             var mockSSM = new Mock<IAmazonSimpleSystemsManagement>();


### PR DESCRIPTION
...via the Standard ASP.NET Core Configuration Means

*Issue #, if available:*

#8

*Description of changes:*

Adds a new overload of the `PersistKeysToAWSSystemsManager` method capable of taking no parameters which retrieves the value of `parameterNamePrefix` from ASP.NET Core configuration. This is done by adding a `ParameterNamePrefix` property to the `PersistOptions` class.

✔️ By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
