### PR TITLE
Add advanced tier usage option for large keys

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.35.4" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.102.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
@@ -15,6 +15,7 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Amazon.SimpleSystemsManagement;
 
 namespace Amazon.AspNetCore.DataProtection.SSM
 {
@@ -28,5 +29,11 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         /// don't specify a key ID, the system uses the default key associated with your AWS account.
         /// </summary>
         public string KMSKeyId { get; set; }
+
+        /// <summary>
+        /// Whether the store is allowed to create SNN parameters using the Advanced Tier pricing in case that the stored key is to big for standard tier.
+        /// Standard tier maximum size is 4096 characters (4KB).
+        /// </summary>
+        public bool CanUseAdvancedTier { get; set; }
     }
 }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
@@ -12,9 +12,7 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   express or implied. See the License for the specific language governing
   permissions and limitations under the License.
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
+
 using Amazon.SimpleSystemsManagement;
 
 namespace Amazon.AspNetCore.DataProtection.SSM
@@ -31,9 +29,10 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         public string KMSKeyId { get; set; }
 
         /// <summary>
-        /// Whether the store is allowed to create SNN parameters using the Advanced Tier pricing in case that the stored key is to big for standard tier.
-        /// Standard tier maximum size is 4096 characters (4KB).
+        /// Highest storage tier that can get used. Higher tiers allow more characters which is required for larger keys.
+        /// Even if a higher tier is configured, the lowest possible tier will be chosen when creating the parameter.
+        /// The default tier is 'Standard' (4096 characters).
         /// </summary>
-        public bool CanUseAdvancedTier { get; set; }
+        public ParameterTier TierStorageMode { get; set; } = ParameterTier.Standard;
     }
 }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
@@ -29,10 +29,9 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         public string KMSKeyId { get; set; }
 
         /// <summary>
-        /// Highest storage tier that can get used. Higher tiers allow more characters which is required for larger keys.
-        /// Even if a higher tier is configured, the lowest possible tier will be chosen when creating the parameter.
-        /// The default tier is 'Standard' (4096 characters).
+        /// Storage mode to decide which parameter storage tier will be used. Default is <see cref="TierStorageMode.StandardOnly"/>.
+        /// Higher tiers allow more characters which is required for larger keys.
         /// </summary>
-        public ParameterTier TierStorageMode { get; set; } = ParameterTier.Standard;
+        public TierStorageMode TierStorageMode { get; set; } = TierStorageMode.StandardOnly;
     }
 }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMParameterToLongException.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMParameterToLongException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Amazon.AspNetCore.DataProtection.SSM
+{
+    /// <summary>
+    /// Thrown when a parameter should be stored that exceeds the configured <see cref="PersistOptions.TierStorageMode"/>
+    /// tiers maximum length.
+    /// </summary>
+    public class SSMParameterToLongException : Exception
+    {
+        public SSMParameterToLongException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
@@ -211,11 +211,9 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                 { 
                     throw new SSMParameterToLongException($"Could not save DataProtection element to SSM parameter. " +
                                                           $"Element has {elementValueLength} characters which exceeds the limit of {standardTierMaxSize} characters of the standard parameter tier and usage of advanced tier is not configured." +
-                                                          $"Please consider using another key provider or key store.");
+                                                          $"You can resolve this issue by changing the TierStorageMode to {nameof(TierStorageMode.AdvancedUpgradeable)} or {nameof(TierStorageMode.AdvancedOnly)} in the configuration.");
                 }
-
-                _logger.LogDebug(
-                    $"Tier mode allows usage of advanced SSM parameter tier for large DataProtection element.");
+ 
                 return ParameterTier.Advanced;
             }
              

--- a/src/Amazon.AspNetCore.DataProtection.SSM/TierStorageMode.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/TierStorageMode.cs
@@ -1,0 +1,21 @@
+﻿namespace Amazon.AspNetCore.DataProtection.SSM
+{
+    /// <summary>
+    /// Mode to decide which parameter storage tier will be used.
+    /// </summary>
+    public enum TierStorageMode
+    {
+        /// <summary>
+        /// Default. Will only use standard tier or fail if the value won't fit.
+        /// </summary>
+        StandardOnly,
+        /// <summary>
+        /// Use advanced tier if the value won't fit in standard tier.
+        /// </summary>
+        AdvancedUpgradeable, 
+        /// <summary>
+        /// Always use advanced tier.
+        /// </summary>
+        AdvancedOnly
+    }
+}

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\PersistOptions.cs" Link="LinkedFiles\PersistOptions.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMXmlRepository.cs" Link="LinkedFiles\SSMXmlRepository.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMParameterToLongException.cs" Link="LinkedFiles\SSMParameterToLongException.cs" />
+    <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\TierStorageMode.cs" Link="LinkedFiles\TierStorageMode.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -10,11 +10,12 @@
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\ExtensionMethods.cs" Link="LinkedFiles\ExtensionMethods.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\PersistOptions.cs" Link="LinkedFiles\PersistOptions.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMXmlRepository.cs" Link="LinkedFiles\SSMXmlRepository.cs" />
+    <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMParameterToLongException.cs" Link="LinkedFiles\SSMParameterToLongException.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.6" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.35.4" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.103.2" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />


### PR DESCRIPTION
Using the SSN parameter advanced tier is required when the key exceeds
4096 characters which is the maximum size of standard tier SSN
parameters. This adds the CanUseAdvancedTier parameter to the
PersistOptions. When creating the parameter, the length of the key
will be evaluated and the advanced tier will be used if required and
configured. When the length exceeds the standard tier size and advanced
tier usage is not configured, an exception will be thrown. When the key
size exceeds the advanced tier, an exception will be thrown aswell.

Tests are missing at this point but I will add them if you would like to merge the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
