### PR TITLE
Support tagging parameters

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/PersistOptions.cs
@@ -13,6 +13,7 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   permissions and limitations under the License.
  */
 
+using System.Collections.Generic;
 using Amazon.SimpleSystemsManagement;
 
 namespace Amazon.AspNetCore.DataProtection.SSM
@@ -33,5 +34,10 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         /// Higher tiers allow more characters which is required for larger keys.
         /// </summary>
         public TierStorageMode TierStorageMode { get; set; } = TierStorageMode.StandardOnly;
+
+        /// <summary>
+        /// The optional tags to apply to parameters created in the Parameter Store.
+        /// </summary>
+        public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
@@ -14,17 +14,18 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  */
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
+using Amazon.Runtime;
 using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
-using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
-using Amazon.Runtime;
-using System.Reflection; 
 
 namespace Amazon.AspNetCore.DataProtection.SSM
 {
@@ -159,6 +160,13 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                     Description = "ASP.NET Core DataProtection Key",
                     Tier = tier
                 };
+
+                if (_options.Tags?.Count > 0)
+                {
+                    request.Tags = _options.Tags
+                        .Select(tag => new Tag() { Key = tag.Key, Value = tag.Value })
+                        .ToList();
+                }
 
                 if (!string.IsNullOrEmpty(_options.KMSKeyId))
                 {


### PR DESCRIPTION
Add support for tagging parameters created in SSM.

Resolves #45.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
