### PR TITLE
Fix code analysis warnings

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMParameterToLongException.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMParameterToLongException.cs
@@ -6,8 +6,14 @@ namespace Amazon.AspNetCore.DataProtection.SSM
     /// Thrown when a parameter should be stored that exceeds the configured <see cref="PersistOptions.TierStorageMode"/>
     /// tiers maximum length.
     /// </summary>
+#pragma warning disable CA1032 // Implement standard exception constructors
     public class SSMParameterToLongException : Exception
+#pragma warning restore CA1032 // Implement standard exception constructors
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SSMParameterToLongException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
         public SSMParameterToLongException(string message) : base(message)
         {
         }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
@@ -101,11 +101,11 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                 request.NextToken = response?.NextToken;
                 try
                 {
-                    response = await _ssmClient.GetParametersByPathAsync(request);
+                    response = await _ssmClient.GetParametersByPathAsync(request).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError($"Error calling SSM to get parameters starting with {_parameterNamePrefix}: {e.Message}");
+                    _logger.LogError(e, $"Error calling SSM to get parameters starting with {_parameterNamePrefix}: {e.Message}");
                     throw;
                 }
 
@@ -116,9 +116,11 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                         var xml = XElement.Parse(parameter.Value);
                         results.Add(xml);
                     }
+#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                     {
-                        _logger.LogError($"Error parsing key {parameter.Name}, key will be skipped: {e.Message}");
+                        _logger.LogError(e, $"Error parsing key {parameter.Name}, key will be skipped: {e.Message}");
                     }
                 }
 
@@ -165,13 +167,13 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                     request.KeyId = _options.KMSKeyId;
                 }
 
-                await _ssmClient.PutParameterAsync(request);
+                await _ssmClient.PutParameterAsync(request).ConfigureAwait(false);
 
                 _logger.LogInformation($"Saved DataProtection key to SSM Parameter Store with parameter name {parameterName}");
             }
             catch (Exception e)
             {
-                _logger.LogError($"Error saving DataProtection key to SSM Parameter Store with parameter name {parameterName}: {e.Message}");
+                _logger.LogError(e, $"Error saving DataProtection key to SSM Parameter Store with parameter name {parameterName}: {e.Message}");
                 throw;
             }
         }
@@ -221,7 +223,7 @@ namespace Amazon.AspNetCore.DataProtection.SSM
         }
 
         #region IDisposable Support
-        private bool disposedValue = false;
+        private bool disposedValue;
 
         protected virtual void Dispose(bool disposing)
         {
@@ -248,7 +250,7 @@ namespace Amazon.AspNetCore.DataProtection.SSM
             {
                 amazonSimpleSystemsManagementClient.BeforeRequestEvent += (object sender, RequestEventArgs e) =>
                 {
-                    var args = e as Amazon.Runtime.WebServiceRequestEventArgs;
+                    var args = e as WebServiceRequestEventArgs;
                     if (args == null || !args.Headers.ContainsKey(UserAgentHeader))
                         return;
 


### PR DESCRIPTION
Fix code analysis issues/warnings found while developing #48.

- Pass exception through to `LogError()`.
- Add calls to `ConfigureAwait(false).
- Add missing XML documentation.
- Suppress CA1032 on `SSMParameterToLongException` (sic).
- Suppress CA1031.
- Remove redundant assignment and namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
