### PR TITLE
Rework Microsoft.AspNetCore.DataProtection.Extensions dependency inclusion

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
@@ -20,7 +20,7 @@
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
     <SignOnBuild>true</SignOnBuild>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <Choose>
@@ -44,7 +44,14 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.17.46" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.28" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-ssm-data-protection-provider-for-aspnet/issues/54

*Description of changes:*
When users include this package into their ASP.NET Core application we want the `Microsoft.AspNetCore.DataProtection.Extensions` dependency used by this package to come from the runtime and not be include into the deployment bundle. Otherwise we are unnecessarily bloating the deployment bundle. We also want patching to be take care of by updating to the latest version of .NET. Users shouldn't have to also update their deployment bundle.

The fix adds a conditional `PackageReference` based on target framework. For each target framework the library supports include the minimum version of Microsoft.AspNetCore.DataProtection.Extensions for the target framework which will tell the `dotnet publish` to not include in the deployment bundle and use what is installed with the runtime.

I confirmed after this change that publishing both .NET 3.1 or 6 apps did not include any additional dlls besides this library in the deployment bundle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
