### PR TITLE
Latest Microsoft.AspNetCore.DataProtection.Extensions for each target framework

### DIFF
--- a/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
@@ -47,11 +47,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="3.1.32" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="6.0.24" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
References to this packages are reporting it as insecure due to its transitive dependencies. In this case `Microsoft.AspNetCore.DataProtection.Extensions` which eventually references `System.Security.Cryptography.Xml`, with known vulnerabilities for <= 6.0.0 versions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
