### PR TITLE
Update .NET target to use version 8.0.11 of Microsoft.AspNetCore.DataProtection

### DIFF
--- a/.autover/changes/a4a0c85b-5951-4aae-838f-7e23dce1c71d.json
+++ b/.autover/changes/a4a0c85b-5951-4aae-838f-7e23dce1c71d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.AspNetCore.DataProtection.SSM",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update .NET target to use version 8.0.11 of Microsoft.AspNetCore.DataProtection"
+      ]
+    }
+  ]
+}

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -4,6 +4,10 @@ phases:
   install:
     runtime-versions:
       dotnet: 8.x
+    commands:
+      # Find and delete the global.json files that were added by CodeBuild. This causes issues when multiple SDKs are installed.
+      - find / -type f -name 'global.json' -delete
+      - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0
   build:
     commands:
       - dotnet test test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj -c Release --logger trx --results-directory ./testresults

--- a/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
@@ -36,11 +36,20 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.403.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.0" />  
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	  
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
+  </ItemGroup>
+  
 
 </Project>

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-ssm-data-protection-provider-for-aspnet/issues/78

*Description of changes:*
In the previous release the dependency for `Microsoft.AspNetCore.DataProtection` was set to 9.0.0 for all targets of the library. This was to address security vulnerabilities in previous versions and we figured we would match `Microsoft.AspNetCore.DataProtection.StackExchangeRedis` pattern of targeting 9.0.0 for all targets.

As @dosolkowski-work pointed out in the issue Microsoft also publishes updated versions in for previous targets at the same time. Meaning they also updated the 8.X versions of `Microsoft.AspNetCore.DataProtection` recently to handle the security vulnerabilities. Even though the 9.0.0 version works in a .NET 8 application there is the assumption the 9.0.0 has the same non-LTS support cycle.

This PR slightly reverses the previous change by for the .NET 8 target of the library it will use the 8.0.11 version. The .NET Standard 2.0 fallback target for anybody using an unsupported version of .NET will still use the latest 9.0.0 version.

*Testing*
* Updated the test project to multi target .NET 8 and .NET 9. Tests ran successful
* Build the NuGet package locally and confirmed expected behavior and packaging when referencing the package for both a .NET 8 and 9 application.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
