### PR TITLE
Updated SSMXmlRepository to implement IDeletableXmlRepository for .NET 9 target.

### DIFF
--- a/.autover/changes/5caae1ce-fbf8-485c-a34f-b05f32ef0b52.json
+++ b/.autover/changes/5caae1ce-fbf8-485c-a34f-b05f32ef0b52.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.AspNetCore.DataProtection.SSM",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Updated SSMXmlRepository to implement IDeletableXmlRepository for .NET 9 target."
+      ]
+    }
+  ]
+}

--- a/src/Amazon.AspNetCore.DataProtection.SSM/ExtensionMethods.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/ExtensionMethods.cs
@@ -12,19 +12,14 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   express or implied. See the License for the specific language governing
   permissions and limitations under the License.
  */
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.AspNetCore.DataProtection;
-
 using Amazon.AspNetCore.DataProtection.SSM;
 using Amazon.SimpleSystemsManagement;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -77,6 +72,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.XmlRepository = new SSMXmlRepository(ssmClient, parameterNamePrefix, ssmOptions, loggerFactory);
                 });
             });
+
+#if NET9_0_OR_GREATER
+            builder.Services.AddSingleton<IKeyManager, XmlDeletableKeyManager>();
+#endif
 
             return builder;
         }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/SSMXmlRepository.cs
@@ -26,13 +26,25 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Amazon.Runtime;
 using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
+using System.IO;
+using System.Diagnostics;
 
 namespace Amazon.AspNetCore.DataProtection.SSM
 {
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Implementation of IDeletableXmlRepository that handles storing, retrieving and deleting DataProtection keys from the SSM Parameter Store. 
+    /// </summary>
+    internal class SSMXmlRepository :
+        IDeletableXmlRepository
+#else
     /// <summary>
     /// Implementation of IXmlRepository that handles storing and retrieving DataProtection keys from the SSM Parameter Store. 
     /// </summary>
-    internal class SSMXmlRepository : IXmlRepository, IDisposable
+    internal class SSMXmlRepository :
+        IXmlRepository
+#endif
+        , IDisposable
     {
         const string UserAgentHeader = "User-Agent";
         private static readonly string _assemblyVersion = typeof(SSMXmlRepository).GetTypeInfo().Assembly.GetName().Version.ToString();
@@ -192,6 +204,96 @@ namespace Amazon.AspNetCore.DataProtection.SSM
             }
         }
 
+#if NET9_0_OR_GREATER
+        /// <inheritdoc/>
+        public bool DeleteElements(Action<IReadOnlyCollection<IDeletableElement>> chooseElements)
+        {
+            return Task.Run(() => DeleteElementsAsync(chooseElements)).GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> DeleteElementsAsync(Action<IReadOnlyCollection<IDeletableElement>> chooseElements)
+        {
+            if (chooseElements == null)
+            {
+                throw new ArgumentNullException(nameof(chooseElements));
+            }
+
+            var deletableElements = new List<DeletableElement>();
+            var request = new GetParametersByPathRequest
+            {
+                Path = _parameterNamePrefix,
+                WithDecryption = true
+            };
+            GetParametersByPathResponse response = null;
+
+            do
+            {
+                request.NextToken = response?.NextToken;
+                try
+                {
+                    response = await _ssmClient.GetParametersByPathAsync(request).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(
+                        e,
+                        "Error calling SSM to get parameters starting with {ParameterNamePrefix}: {ExceptionMessage}",
+                        _parameterNamePrefix,
+                        e.Message);
+
+                    throw;
+                }
+
+                foreach (var parameter in response.Parameters)
+                {
+                    try
+                    {
+                        var xml = XElement.Parse(parameter.Value);
+                        deletableElements.Add(new DeletableElement(parameter, xml));
+                    }
+#pragma warning disable CA1031 // Do not catch general exception types
+                    catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
+                    {
+                        _logger.LogError(e, "Error parsing key {ParameterName}, key will be skipped: {ExceptionMessage}", parameter.Name, e.Message);
+                    }
+                }
+
+            } while (!string.IsNullOrEmpty(response.NextToken));
+
+            chooseElements(deletableElements);
+
+            var elementsToDelete = deletableElements
+                .Where(e => e.DeletionOrder.HasValue)
+                .OrderBy(e => e.DeletionOrder.GetValueOrDefault());
+
+            foreach (var deletableElement in elementsToDelete)
+            {
+                var parameter = deletableElement.Parameter;
+
+                _logger.LogDebug("Deleting DataProtection key from SSM Parameter Store with parameter name {ParameterName}", parameter.Name);
+                try
+                {
+                    var deleteParameterRequest = new DeleteParameterRequest
+                    {
+                        Name = parameter.Name
+                    };
+
+                    await _ssmClient.DeleteParameterAsync(deleteParameterRequest).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to delete DataProtection key from SSM Parameter Store with parameter name {ParameterName}: {ExceptionMessage}", parameter.Name, ex.Message);
+
+                    // Stop processing deletions to avoid deleting a revocation entry for a key that we failed to delete.
+                    return false;
+                }
+            }
+
+            return true;
+        }
+#endif
+
         /// <summary>
         /// Gets the <see cref="ParameterTier"/> to use for the <paramref name="elementValue"/> based on the <paramref name="elementValue"/> length and configured <see cref="TierStorageMode"/>. 
         /// </summary>
@@ -276,5 +378,25 @@ namespace Amazon.AspNetCore.DataProtection.SSM
                 };
             }
         }
+
+#if NET9_0_OR_GREATER
+        private sealed class DeletableElement : IDeletableElement
+        {
+            public DeletableElement(Parameter parameter, XElement element)
+            {
+                Parameter = parameter;
+                Element = element;
+            }
+
+            /// <summary>The Parameter from which <see cref="Element"/> was read.</summary>
+            public Parameter Parameter { get; }
+
+            /// <inheritdoc/>
+            public XElement Element { get; }
+
+            /// <inheritdoc/>
+            public int? DeletionOrder { get; set; }
+        }
+#endif
     }
 }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/XmlDeletableKeyManager.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/XmlDeletableKeyManager.cs
@@ -1,0 +1,90 @@
+﻿/*
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+ */
+
+using Microsoft.AspNetCore.DataProtection.Internal;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Amazon.AspNetCore.DataProtection.SSM
+{
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Extension of XmlKeyManager which supports key deletion.
+    /// 
+    /// <para>
+    /// XmlKeyManager implements IKeyManager but doesn't have the declaration for implementing IDeletableKeyManager. 
+    /// We created our wrapper to have the IDeletableKeyManager declaration. Refer https://github.com/dotnet/aspnetcore/discussions/60315 for more details.
+    /// </para>
+    /// </summary>
+    internal class XmlDeletableKeyManager : IDeletableKeyManager
+    {
+        XmlKeyManager _xmlKeyManager;
+
+        /// <summary>
+        /// Initializes a new instance of XmlDeletableKeyManager class.
+        /// </summary>
+        /// <param name="keyManagementOptions"></param>
+        /// <param name="activator"></param>
+        public XmlDeletableKeyManager(IOptions<KeyManagementOptions> keyManagementOptions, IActivator activator)
+        {
+            _xmlKeyManager = new XmlKeyManager(keyManagementOptions, activator);
+        }
+
+        /// <inheritdoc/>
+        public bool CanDeleteKeys => _xmlKeyManager.CanDeleteKeys;
+
+        /// <inheritdoc/>
+        public bool DeleteKeys(Func<IKey, bool> shouldDelete)
+        {
+            return _xmlKeyManager.DeleteKeys(shouldDelete);
+        }
+
+        #region IKeyManager implementation
+        /// <inheritdoc/>
+        public IKey CreateNewKey(DateTimeOffset activationDate, DateTimeOffset expirationDate)
+        {
+            return _xmlKeyManager.CreateNewKey(activationDate, expirationDate);
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<IKey> GetAllKeys()
+        {
+            return _xmlKeyManager.GetAllKeys();
+        }
+
+        /// <inheritdoc/>
+        public CancellationToken GetCacheExpirationToken()
+        {
+            return _xmlKeyManager.GetCacheExpirationToken();
+        }
+
+        /// <inheritdoc/>
+        public void RevokeAllKeys(DateTimeOffset revocationDate, string reason = null)
+        {
+            _xmlKeyManager.RevokeAllKeys(revocationDate, reason);
+        }
+
+        /// <inheritdoc/>
+        public void RevokeKey(Guid keyId, string reason = null)
+        {
+            _xmlKeyManager.RevokeKey(keyId, reason);
+        }
+        #endregion
+    }
+#endif
+}

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -12,6 +12,7 @@
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMXmlRepository.cs" Link="LinkedFiles\SSMXmlRepository.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMParameterToLongException.cs" Link="LinkedFiles\SSMParameterToLongException.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\TierStorageMode.cs" Link="LinkedFiles\TierStorageMode.cs" />
+	<Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\XmlDeletableKeyManager.cs" Link="LinkedFiles\XmlDeletableKeyManager.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,8 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
@@ -27,6 +27,7 @@ using System.Xml.Linq;
 using Amazon.SimpleSystemsManagement.Model;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 
 namespace Amazon.AspNetCore.DataProtection.SSM.Tests
 {
@@ -63,6 +64,23 @@ namespace Amazon.AspNetCore.DataProtection.SSM.Tests
 
             AssertDataProtectUnprotect(serviceContainer.BuildServiceProvider());
         }
+
+#if NET9_0_OR_GREATER
+        [Fact]
+        public void CheckXmlDeletableKeyManager()
+        {
+            var serviceContainer = new ServiceCollection();
+
+            serviceContainer.AddDataProtection()
+                .PersistKeysToAWSSystemsManager("/MyApplication/DataProtection");
+
+            var serviceProvider = serviceContainer.BuildServiceProvider();
+            var keyManager = serviceProvider.GetService<IKeyManager>();
+
+            Assert.True(keyManager is IDeletableKeyManager);
+            Assert.True((keyManager as IDeletableKeyManager).CanDeleteKeys);
+        }
+#endif
 
         private IAmazonSimpleSystemsManagement CreateMockSSMClient(string kmsKeyId)
         {


### PR DESCRIPTION
*Issue #:* DOTNET-7827

*Description of changes:*
Updated `SSMXmlRepository` to implement `IDeletableXmlRepository` for `.NET 9` target.

Referenced Microsoft's implementation of [FileSystemXmlRepository](https://github.com/dotnet/aspnetcore/blob/1770dcf4e81872395cc4d3b3b3efbaef91f8020a/src/DataProtection/DataProtection/src/Repositories/FileSystemXmlRepository.cs#L87).

**Additional Changes:**
- Updated Readme with an example and additional needed permission to delete System Manager parameter for .NET 9 target.
- Generated `autover` file with increment type as `Minor` since it's a new feature.

~~Kindly note that Visual Studio was reporting `IDeletableXmlRepository` to be available in `NETSTANDARD 2.0` as well. Unsure if should include it in the conditional compilation target.~~ **Per @normj, we can keep .NET 9 target for now**

**Testing:**
- Did a manual test from an ASP.NET Core application to confirm the behavior works as expected (~~it might not be possible since key expiration should be at least 7 days~~, but there were no exceptions) and there isn't anything else that needs to be implemented.
- **End-to-End testing** (on Mac)
  - Install Visual Studio Code, C# Dev Kit extension and .NET 9.0 SDK.
  - Clone GitHub repository for `aws-ssm-data-protection-provider-for-aspnet` and switch to branch `user/ashdhin/IDeletableXmlRepository-DOTNET-7827` containing the change in this PR.
  - Created new ASP.NET Core Web Application project targeting .NET 9. Make the following changes:
    - Add project reference to the `aws-ssm-data-protection-provider-for-aspnet\src\Amazon.AspNetCore.DataProtection.SSM\Amazon.AspNetCore.DataProtection.SSM.csproj`. For my setup it looks like below:
      **.csproj**
      ```XML
      <Project Sdk="Microsoft.NET.Sdk.Web">
      
        <PropertyGroup>
          <TargetFramework>net9.0</TargetFramework>
          <Nullable>enable</Nullable>
          <ImplicitUsings>enable</ImplicitUsings>
        </PropertyGroup>
       
        <ItemGroup>
          <ProjectReference Include="..\..\..\source\GitHub\aws\aws-ssm-data-protection-provider-for-aspnet\src\Amazon.AspNetCore.DataProtection.SSM\Amazon.AspNetCore.DataProtection.SSM.csproj" />
        </ItemGroup>
      
      </Project>
      ``` 
    - Modify **Program.cs** to below:
      ```C#
      using Microsoft.AspNetCore.DataProtection;
      using Microsoft.AspNetCore.DataProtection.KeyManagement;
      using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
      using Microsoft.Extensions.DependencyInjection;
      
      var builder = WebApplication.CreateBuilder(args);
      
      // Add services to the container.
      builder.Services.AddControllersWithViews();
      builder.Services.AddDataProtection()
          .SetDefaultKeyLifetime(TimeSpan.FromDays(7))
          .PersistKeysToAWSSystemsManager("/MyApplication/DataProtection");
      
      var app = builder.Build();
      
      var keyManager = app.Services.GetService<IKeyManager>();
      
      if (keyManager is XmlKeyManager xmlKeyManager)
      {
          if (xmlKeyManager.CanDeleteKeys)
          {
              var utcNow = DateTimeOffset.UtcNow;
              var sevenDaysAgo = utcNow.AddDays(-7);
      
              if (!xmlKeyManager.DeleteKeys(key => key.ExpirationDate < sevenDaysAgo))
              {
                  Console.WriteLine("Failed to delete keys.");
              }
              else
              {
                  Console.WriteLine("Old keys deleted successfully.");
              }
          }
      }
      else
      {
          Console.WriteLine("Key manager does not support deletion.");
      }
      
      // Configure the HTTP request pipeline.
      if (!app.Environment.IsDevelopment())
      {
          app.UseExceptionHandler("/Home/Error");
          // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
          app.UseHsts();
      }
      
      app.UseHttpsRedirection();
      app.UseRouting();
      
      app.UseAuthorization();
      
      app.MapStaticAssets();
      
      app.MapControllerRoute(
          name: "default",
          pattern: "{controller=Home}/{action=Index}/{id?}")
          .WithStaticAssets();
      
      
      app.Run();
      ```
    This sets the default key lifetime to 7 days (minimum as we could set) and sets delegate condition to delete keys older than 7 days.

  - On Mac, adjust date to 10 days back.
  - Run the application using Visual Studio Code debug once. This will create data protection key in Systems Manager Parameter Store.
  - Stop the application.
  - Now set Data in Mac system settings to current date (sync date and time automatically).
  - Run the application using Visual Studio Code debug. This will expire old data protection key and create a new one in Systems Manager Parameter Store. Examine that the expired key as `expirationDate` element.
  - Stop the application. We want to run delete keys logic during application start to test the changes.
  - Setup breakpoints in new code if required OR we may step into code while debugging.
  - Run the application using Visual Studio Code debug. This time when delete keys logic is run, it will find the expired key (based on delegate) and delete it using the newly added logic in this PR.

**Question:** ~~How is DeleteElements used in actual ASP.NET application? How do we set its delegate that chooses elements?~~
**Answer:** Key deletion is handled by the logic in web application. Refer below code (excerpt taken from [Data Protection key management and lifetime in ASP.NET Core: Delete keys](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/default-settings?view=aspnetcore-9.0#delete-keys)):
```C#
﻿using Microsoft.AspNetCore.DataProtection.KeyManagement;

var services = new ServiceCollection();
services.AddDataProtection();

var serviceProvider = services.BuildServiceProvider();

var keyManager = serviceProvider.GetService<IKeyManager>();

if (keyManager is IDeletableKeyManager deletableKeyManager)
{
    var utcNow = DateTimeOffset.UtcNow;
    var yearAgo = utcNow.AddYears(-1);

    if (!deletableKeyManager.DeleteKeys(key => key.ExpirationDate < yearAgo))
    {
        Console.WriteLine("Failed to delete keys.");
    }
    else
    {
        Console.WriteLine("Old keys deleted successfully.");
    }
}
else
{
    Console.WriteLine("Key manager does not support deletion.");
}
```
- `services.AddDataProtection()` uses [AddDataProtectionServices](https://github.com/dotnet/aspnetcore/blob/c43eb9a914f5e867c3c488e6b745f8bb28ebcaca/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs#L59C25-L59C50) internally.
- It configures `XmlKeyManager` [here](https://github.com/dotnet/aspnetcore/blob/c43eb9a914f5e867c3c488e6b745f8bb28ebcaca/src/DataProtection/DataProtection/src/DataProtectionServiceCollectionExtensions.cs#L75C47-L75C60).
- [XmlKeyManager](https://github.com/dotnet/aspnetcore/blob/c43eb9a914f5e867c3c488e6b745f8bb28ebcaca/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs#L35C21-L35C35) has a property [CanDeleteKeys](https://github.com/dotnet/aspnetcore/blob/c43eb9a914f5e867c3c488e6b745f8bb28ebcaca/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs#L411) which returns `true` is the underlying `KeyRepository` implements `IDeletableXmlRepository`.
- [IDeletableKeyManager](https://github.com/dotnet/aspnetcore/blob/c43eb9a914f5e867c3c488e6b745f8bb28ebcaca/src/DataProtection/DataProtection/src/KeyManagement/IDeletableKeyManager.cs#L14) is an extension of `IKeyManager` that supports key deletion.

Out `SSMXmlRepository` is just a repository for storing keys.

Based on code excerpt above, **unsure how `XmlKeyManager` would delete keys since it doesn't implement `IDeletableKeyManager`**. So above code (appears to be incorrect since `XmlKeyManager` cannot be replaced while invoking `services.AddDataProtection()`), should be modified to below:
```C#
﻿using Microsoft.AspNetCore.DataProtection.KeyManagement;

var services = new ServiceCollection();
services.AddDataProtection();

var serviceProvider = services.BuildServiceProvider();

var keyManager = serviceProvider.GetService<IKeyManager>();

if (keyManager.CanDeleteKeys)
{
    var utcNow = DateTimeOffset.UtcNow;
    var yearAgo = utcNow.AddYears(-1);

    if (!deletableKeyManager.DeleteKeys(key => key.ExpirationDate < yearAgo))
    {
        Console.WriteLine("Failed to delete keys.");
    }
    else
    {
        Console.WriteLine("Old keys deleted successfully.");
    }
}
else
{
    Console.WriteLine("Key manager does not support deletion.");
}
```

Started discussion https://github.com/dotnet/aspnetcore/discussions/60315 in ASP.NET Core repo.

**IMPORTANT NOTE:** There are few tests, that `Assert` `NotNull` and `Empty` on request Tags. This would fail for AWS SDK for .NET 4 since by default, collections wouldn't be initialized. Perhaps an action item for all HLLs.


___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
