### PR TITLE
chore: Pinned to v1.6.0 of aws-github-ops/handle-stale-discussions so that closed GitHub discussions are not auto-reopened.

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -13,6 +13,6 @@ jobs:
       discussions: write
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@711a9813957be17629fc6933afcd8bd132c57254 #v1.6
+        uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 #v1.6.0
         env:
           GITHUB_TOKEN:  ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Closed GitHub Q&A discussions were auto-reopened. The latest changes for not to reopen closed discussions were not released. Worked with the concerned team to get the changes released in `v1.6.0`.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
