### PR TITLE
Route PR reviews to the DevEx squad via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/aws-sdk-dotnet-team
+* @aws/aws-sdk-devex-reviewers @aws/aws-sdk-dotnet-team


### PR DESCRIPTION
Updates CODEOWNERS to list the DevEx reviewers child team as a co-owner alongside the parent `aws-sdk-dotnet-team`. This lets GitHub auto-assign a single squad member as the primary reviewer (via round-robin on the child team) while keeping the parent team as a secondary owner so approvals from any team member still satisfy code-owner review.

Context: our team is setting up subteam-based review routing so PRs land on the right squad without losing cross-team visibility. The parent team has no auto-assignment configured; the child team handles round-robin. Either team's approval satisfies the code-owner rule.

Related docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
