### PR TITLE
Add ProtectKeysWithAwsKms to separate encryption from persistence

### DIFF
--- a/.autover/changes/separate-persist-and-protect.json
+++ b/.autover/changes/separate-persist-and-protect.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.AspNetCore.DataProtection.SSM",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Added ProtectKeysWithAwsKms extension method to separate key encryption (KMS) from key persistence (SSM), following the same pattern as Azure's ProtectKeysWithAzureKeyVault"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/Amazon.AspNetCore.DataProtection.SSM.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.25" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.8" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="4.0.7.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Amazon.AspNetCore.DataProtection.SSM/ExtensionMethods.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/ExtensionMethods.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License").
@@ -13,9 +13,11 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   permissions and limitations under the License.
  */
 using Amazon.AspNetCore.DataProtection.SSM;
+using Amazon.KeyManagementService;
 using Amazon.SimpleSystemsManagement;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -76,6 +78,57 @@ namespace Microsoft.Extensions.DependencyInjection
 #if NET9_0_OR_GREATER
             builder.Services.AddSingleton<IKeyManager, XmlDeletableKeyManager>();
 #endif
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configures the data protection system to protect keys with AWS KMS. This separates the encryption
+        /// concern from the persistence concern, allowing you to use any persistence provider (SSM, Redis, 
+        /// file system, etc.) while encrypting keys at rest with KMS.
+        /// <para>
+        /// When using this method with <see cref="PersistKeysToAWSSystemsManager(IDataProtectionBuilder, string)"/>, the SSM parameters will
+        /// be stored as encrypted XML (encrypted by the Data Protection framework using KMS) rather than relying
+        /// on SSM's SecureString parameter type.
+        /// </para>
+        /// </summary>
+        /// <param name="builder">The <see cref="IDataProtectionBuilder"/>.</param>
+        /// <param name="kmsKeyId">The KMS key ID, ARN, alias name, or alias ARN to use for encryption.</param>
+        /// <returns>The <see cref="IDataProtectionBuilder"/>.</returns>
+        /// <example>
+        /// <code>
+        /// // Use SSM for persistence and KMS for encryption (separated concerns)
+        /// services.AddDataProtection()
+        ///     .PersistKeysToAWSSystemsManager("/MyApp/DataProtection")
+        ///     .ProtectKeysWithAwsKms("arn:aws:kms:us-east-1:123456789012:key/my-key-id");
+        ///
+        /// // Use Redis for persistence and KMS for encryption
+        /// services.AddDataProtection()
+        ///     .PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys")
+        ///     .ProtectKeysWithAwsKms("alias/my-data-protection-key");
+        /// </code>
+        /// </example>
+        public static IDataProtectionBuilder ProtectKeysWithAwsKms(this IDataProtectionBuilder builder, string kmsKeyId)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (string.IsNullOrEmpty(kmsKeyId))
+            {
+                throw new ArgumentNullException(nameof(kmsKeyId));
+            }
+
+            builder.Services.TryAddAWSService<IAmazonKeyManagementService>();
+
+            builder.Services.AddSingleton<IXmlEncryptor>(services =>
+            {
+                var kmsClient = services.GetRequiredService<IAmazonKeyManagementService>();
+                var loggerFactory = services.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+                return new KmsXmlEncryptor(kmsClient, kmsKeyId, loggerFactory);
+            });
+
+            builder.Services.AddSingleton<IXmlDecryptor, KmsXmlDecryptor>();
 
             return builder;
         }

--- a/src/Amazon.AspNetCore.DataProtection.SSM/KmsXmlDecryptor.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/KmsXmlDecryptor.cs
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+ */
+using System;
+using System.IO;
+using System.Xml.Linq;
+
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
+
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Amazon.AspNetCore.DataProtection.SSM
+{
+    /// <summary>
+    /// An <see cref="IXmlDecryptor"/> that decrypts XML elements using AWS KMS.
+    /// </summary>
+    public sealed class KmsXmlDecryptor : IXmlDecryptor
+    {
+        private readonly IAmazonKeyManagementService _kmsClient;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KmsXmlDecryptor"/>.
+        /// </summary>
+        /// <param name="services">The service provider used to resolve <see cref="IAmazonKeyManagementService"/>.</param>
+        public KmsXmlDecryptor(IServiceProvider services)
+        {
+            _kmsClient = services.GetRequiredService<IAmazonKeyManagementService>();
+            var loggerFactory = services.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+            _logger = loggerFactory.CreateLogger<KmsXmlDecryptor>();
+        }
+
+        /// <inheritdoc/>
+        public XElement Decrypt(XElement encryptedElement)
+        {
+            var ciphertextBase64 = encryptedElement.Element("value")?.Value
+                ?? throw new InvalidOperationException("The encrypted element does not contain a 'value' child element.");
+
+            var ciphertextBytes = Convert.FromBase64String(ciphertextBase64);
+
+            var ciphertextStream = new MemoryStream(ciphertextBytes);
+            try
+            {
+                var response = _kmsClient.DecryptAsync(new DecryptRequest
+                {
+                    CiphertextBlob = ciphertextStream
+                }).GetAwaiter().GetResult();
+
+                _logger.LogDebug("Decrypted DataProtection key using AWS KMS");
+
+                var reader = new StreamReader(response.Plaintext);
+                try
+                {
+                    var xml = reader.ReadToEnd();
+                    return XElement.Parse(xml);
+                }
+                finally
+                {
+                    reader.Dispose();
+                }
+            }
+            finally
+            {
+                ciphertextStream.Dispose();
+            }
+        }
+    }
+}

--- a/src/Amazon.AspNetCore.DataProtection.SSM/KmsXmlEncryptor.cs
+++ b/src/Amazon.AspNetCore.DataProtection.SSM/KmsXmlEncryptor.cs
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  A copy of the License is located at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  or in the "license" file accompanying this file. This file is distributed
+  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express or implied. See the License for the specific language governing
+  permissions and limitations under the License.
+ */
+using System;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
+
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Amazon.AspNetCore.DataProtection.SSM
+{
+    /// <summary>
+    /// An <see cref="IXmlEncryptor"/> that encrypts XML elements using AWS KMS.
+    /// </summary>
+    public sealed class KmsXmlEncryptor : IXmlEncryptor
+    {
+        private readonly IAmazonKeyManagementService _kmsClient;
+        private readonly string _keyId;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KmsXmlEncryptor"/>.
+        /// </summary>
+        /// <param name="kmsClient">The KMS client.</param>
+        /// <param name="keyId">The KMS key ID, ARN, alias name, or alias ARN.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        public KmsXmlEncryptor(IAmazonKeyManagementService kmsClient, string keyId, ILoggerFactory loggerFactory = null)
+        {
+            _kmsClient = kmsClient ?? throw new ArgumentNullException(nameof(kmsClient));
+            _keyId = keyId ?? throw new ArgumentNullException(nameof(keyId));
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<KmsXmlEncryptor>();
+        }
+
+        /// <inheritdoc/>
+        public EncryptedXmlInfo Encrypt(XElement plaintextElement)
+        {
+            var plaintextBytes = Encoding.UTF8.GetBytes(plaintextElement.ToString(SaveOptions.DisableFormatting));
+
+            var plaintextStream = new MemoryStream(plaintextBytes);
+            try
+            {
+                var response = _kmsClient.EncryptAsync(new EncryptRequest
+                {
+                    KeyId = _keyId,
+                    Plaintext = plaintextStream
+                }).GetAwaiter().GetResult();
+
+                _logger.LogDebug("Encrypted DataProtection key using KMS key {KeyId}", _keyId);
+
+                var ciphertextBase64 = Convert.ToBase64String(response.CiphertextBlob.ToArray());
+                var encryptedElement = new XElement("encryptedKey",
+                    new XComment(" This key is encrypted with AWS KMS. "),
+                    new XElement("value", ciphertextBase64));
+
+                return new EncryptedXmlInfo(encryptedElement, typeof(KmsXmlDecryptor));
+            }
+            finally
+            {
+                plaintextStream.Dispose();
+            }
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/Amazon.AspNetCore.DataProtection.SSM.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\ExtensionMethods.cs" Link="LinkedFiles\ExtensionMethods.cs" />
+    <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\KmsXmlEncryptor.cs" Link="LinkedFiles\KmsXmlEncryptor.cs" />
+    <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\KmsXmlDecryptor.cs" Link="LinkedFiles\KmsXmlDecryptor.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\PersistOptions.cs" Link="LinkedFiles\PersistOptions.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMXmlRepository.cs" Link="LinkedFiles\SSMXmlRepository.cs" />
     <Compile Include="..\..\src\Amazon.AspNetCore.DataProtection.SSM\SSMParameterToLongException.cs" Link="LinkedFiles\SSMParameterToLongException.cs" />
@@ -17,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.11" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.8" />
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="4.0.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
+++ b/test/Amazon.AspNetCore.DataProtection.SSM.Tests/ExtensionMethodsTests.cs
@@ -20,9 +20,13 @@ using Xunit;
 
 using Moq;
 
+using Amazon.KeyManagementService;
+using Amazon.KeyManagementService.Model;
 using Amazon.SimpleSystemsManagement;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.XmlEncryption;
+using System.IO;
 using System.Xml.Linq;
 using Amazon.SimpleSystemsManagement.Model;
 using System.Threading;
@@ -81,6 +85,86 @@ namespace Amazon.AspNetCore.DataProtection.SSM.Tests
             Assert.True((keyManager as IDeletableKeyManager).CanDeleteKeys);
         }
 #endif
+
+        [Fact]
+        public void RegisterSSMProviderWithProtectKeysWithAwsKms()
+        {
+            var ssmClient = CreateMockSSMClient(null);
+            var kmsClient = CreateMockKmsClient();
+
+            var serviceContainer = new ServiceCollection()
+                    .AddSingleton<IAmazonSimpleSystemsManagement>(ssmClient)
+                    .AddSingleton<IAmazonKeyManagementService>(kmsClient);
+
+            serviceContainer.AddDataProtection()
+                .PersistKeysToAWSSystemsManager("/RegisterTest")
+                .ProtectKeysWithAwsKms("arn:aws:kms:us-east-1:123456789012:key/test-key");
+
+            var services = serviceContainer.BuildServiceProvider();
+
+            // Verify the encryptor and decryptor are registered
+            var encryptor = services.GetService<IXmlEncryptor>();
+            Assert.NotNull(encryptor);
+            Assert.IsType<KmsXmlEncryptor>(encryptor);
+
+            var decryptor = services.GetService<IXmlDecryptor>();
+            Assert.NotNull(decryptor);
+            Assert.IsType<KmsXmlDecryptor>(decryptor);
+
+            AssertDataProtectUnprotect(services);
+        }
+
+        [Fact]
+        public void ProtectKeysWithAwsKmsThrowsOnNullBuilder()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                ExtensionMethods.ProtectKeysWithAwsKms(null, "key-id"));
+        }
+
+        [Fact]
+        public void ProtectKeysWithAwsKmsThrowsOnNullKeyId()
+        {
+            var serviceContainer = new ServiceCollection();
+            var builder = serviceContainer.AddDataProtection();
+
+            Assert.Throws<ArgumentNullException>(() =>
+                builder.ProtectKeysWithAwsKms(null));
+        }
+
+        private IAmazonKeyManagementService CreateMockKmsClient()
+        {
+            var mockKms = new Mock<IAmazonKeyManagementService>();
+
+            mockKms.Setup(client => client.EncryptAsync(It.IsAny<EncryptRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((EncryptRequest request, CancellationToken token) =>
+                {
+                    // Simulate KMS encryption by just passing through the plaintext (for testing)
+                    var plaintext = new byte[request.Plaintext.Length];
+                    request.Plaintext.Read(plaintext, 0, plaintext.Length);
+                    request.Plaintext.Position = 0;
+
+                    return Task.FromResult(new EncryptResponse
+                    {
+                        CiphertextBlob = new MemoryStream(plaintext)
+                    });
+                });
+
+            mockKms.Setup(client => client.DecryptAsync(It.IsAny<DecryptRequest>(), It.IsAny<CancellationToken>()))
+                .Returns((DecryptRequest request, CancellationToken token) =>
+                {
+                    // Simulate KMS decryption by just passing through the ciphertext (for testing)
+                    var ciphertext = new byte[request.CiphertextBlob.Length];
+                    request.CiphertextBlob.Read(ciphertext, 0, ciphertext.Length);
+                    request.CiphertextBlob.Position = 0;
+
+                    return Task.FromResult(new DecryptResponse
+                    {
+                        Plaintext = new MemoryStream(ciphertext)
+                    });
+                });
+
+            return mockKms.Object;
+        }
 
         private IAmazonSimpleSystemsManagement CreateMockSSMClient(string kmsKeyId)
         {


### PR DESCRIPTION
##
Description

Closes #25 — Separates the persistence and encryption concerns in the Data Protection provider, following the same pattern as Azure's PersistKeysToAzureBlobStorage + ProtectKeysWithAzureKeyVault.

New API
```

// Separated concerns: SSM for persistence, KMS for encryption
services.AddDataProtection()
    .PersistKeysToAWSSystemsManager("/MyApp/DataProtection")
    .ProtectKeysWithAwsKms("arn:aws:kms:us-east-1:123456789012:key/my-key-id");

// Mix with any persistence provider
services.AddDataProtection()
    .PersistKeysToStackExchangeRedis(redis, "DataProtection-Keys")
    .ProtectKeysWithAwsKms("alias/my-data-protection-key");
```

Backward Compatibility

Fully backward compatible. The existing PersistKeysToAWSSystemsManager with KMSKeyId option continues to work unchanged (SSM-managed SecureString encryption). The new ProtectKeysWithAwsKms is an opt-in alternative that uses the Data Protection framework's IXmlEncryptor/IXmlDecryptor pipeline instead.
Testing

    Unit tests: 29/29 (net9.0), 26/26 (net8.0) ✅
    No integration tests in this repo
