### PR TITLE
Harden GitHub Actions workflows based on zizmor audit

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -8,15 +8,22 @@ on:
       - dev
       - 'feature/**'
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-ci:
+    name: Run CI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume AWS roles via OIDC
+      contents: read # to read the repository
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6.0.0
         with:
           role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
           role-duration-seconds: 7200
@@ -24,12 +31,17 @@ jobs:
       - name: Invoke Load Balancer Lambda
         id: lambda
         shell: pwsh
+        env:
+          LOAD_BALANCER_LAMBDA_NAME: ${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}
+          TEST_RUNNER_ACCOUNT_ROLES: ${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}
+          CODE_BUILD_PROJECT_NAME: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+          BRANCH_SHA: ${{ github.sha }}
         run: |
-          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
+          aws lambda invoke response.json --function-name "$env:LOAD_BALANCER_LAMBDA_NAME" --cli-binary-format raw-in-base64-out --payload "{`"Roles`": `"$env:TEST_RUNNER_ACCOUNT_ROLES`", `"ProjectName`": `"$env:CODE_BUILD_PROJECT_NAME`", `"Branch`": `"$env:BRANCH_SHA`"}"
           $roleArn=$(cat ./response.json)
           "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
       - name: Configure Test Runner Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6.0.0
         with:
           role-to-assume: ${{ steps.lambda.outputs.roleArn }}
           role-duration-seconds: 7200
@@ -41,6 +53,8 @@ jobs:
           project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
       - name: CodeBuild Link
         shell: pwsh
+        env:
+          BUILD_ID: ${{ steps.codebuild.outputs.aws-build-id }}
         run: |
-          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          $buildId = "$env:BUILD_ID"
           echo $buildId

--- a/.github/workflows/change-file-in-pr.yml
+++ b/.github/workflows/change-file-in-pr.yml
@@ -4,27 +4,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check-files-in-directory:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Release Not Needed') && !contains(github.event.pull_request.labels.*.name, 'Release PR') }}
     name: Change File Included in PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the PR code and inspect changed files
 
     steps:
       - name: Checkout PR code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get List of Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 #v45
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 #v47.0.5
 
       - name: Check for Change File(s) in .autover/changes/
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           DIRECTORY=".autover/changes/"
-          if echo "${{ steps.changed-files.outputs.all_changed_files }}" | grep -q "$DIRECTORY"; then
+          if echo "$ALL_CHANGED_FILES" | grep -q "$DIRECTORY"; then
             echo "✅ One or more change files in '$DIRECTORY' are included in this PR."
           else
             echo "❌ No change files in '$DIRECTORY' are included in this PR."

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,12 +2,17 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
-permissions:
-  issues: write
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
     auto_comment:
+        name: Auto comment on closed issue
         runs-on: ubuntu-latest
+        permissions:
+          issues: write # to comment on closed issues
         steps:
         - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 #v2
           with:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,21 +11,27 @@ on:
         type: string
         required: false
 
-permissions:
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume AWS roles via OIDC
+      contents: read # to check out the repository
 
     env:
       INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
-      
+
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
@@ -75,10 +81,11 @@ jobs:
         run: autover changelog
       # Push the release branch up as well as the created tag
       - name: Push Changes
+        env:
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
-          branch=${{ steps.create-release-branch.outputs.BRANCH }}
-          git push origin $branch
-          git push origin $branch --tags
+          git push origin "$BRANCH"
+          git push origin "$BRANCH" --tags
       # Get the release name that will be used to create a PR
       - name: Read Release Name
         id: read-release-name
@@ -95,6 +102,9 @@ jobs:
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ env.FG_PAT }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
+          BRANCH: ${{ steps.create-release-branch.outputs.BRANCH }}
         run: |
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
-          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --label "Release PR" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          pr_url="$(gh pr create --title "$VERSION" --label "Release PR" --body "$CHANGELOG" --base dev --head "$BRANCH")"

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -4,13 +4,17 @@ on:
     - cron: '0 */4 * * *'
   discussion_comment:
     types: [created]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   handle-stale-discussions:
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:
-      discussions: write
+      discussions: write # to manage and comment on stale discussions
     steps:
       - name: Stale discussions action
         uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 #v1.6.0

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -3,16 +3,21 @@ name: issue-regression-label
 on:
   issues:
     types: [opened, edited]
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   add-regression-label:
+    name: Add potential-regression label
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # to add or remove the potential-regression label
     steps:
     - name: Fetch template body
       id: check_regression
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
-      env: 
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TEMPLATE_BODY: ${{ github.event.issue.body }}
       with:
@@ -24,9 +29,11 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$GITHUB_REPOSITORY"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$GITHUB_REPOSITORY"
         fi

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -13,19 +13,28 @@ on:
   # Manually trigger the workflow
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Scan
     permissions:
-      security-events: write
+      contents: read # to check out the repository source
+      security-events: write # to upload SARIF results to the code scanning dashboard
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:06938c1f365d3f67b8cedd8bc117607ae64253f88a0e768e9da9408548927dd6
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
       # Fetch project source
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
 
       - run: semgrep ci --sarif > semgrep.sarif
         env:

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -5,14 +5,19 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     name: Stale issue job
+    permissions:
+      issues: write # to label and close stale issues
+      pull-requests: write # to label and close stale pull requests
     steps:
     - uses: aws-actions/stale-issue-cleanup@0604f2edf84a3a66bc0dfb4a30eb07814cbdf440 #v7.1.1
       with:

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -9,9 +9,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions: 
-  contents: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `dev`. 
@@ -24,10 +26,13 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # to assume AWS roles via OIDC
+      contents: write # to push the dev/main sync and create the GitHub Release
     steps:
       # Assume an AWS Role that provides access to the Access Token
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v4
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6.0.0
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
@@ -87,8 +92,11 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ env.FG_PAT }}
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
+          VERSION: ${{ steps.read-release-name.outputs.VERSION }}
+          CHANGELOG: ${{ steps.read-changelog.outputs.CHANGELOG }}
         run: |
-          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+          gh release create "$TAG" --title "$VERSION" --notes "$CHANGELOG"
       # Delete the `releases/next-release` branch
       - name: Clean up
         run: |
@@ -104,6 +112,8 @@ jobs:
       github.event.pull_request.head.ref == 'releases/next-release' &&
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to delete the release tag and the release branch
     steps:
       # Checkout a full clone of the repo using the deploy key (push runs over SSH)
       - name: Checkout code
@@ -132,7 +142,9 @@ jobs:
           echo "TAG=$tag" >> $GITHUB_OUTPUT
       # Delete the tag created by AutoVer and the release branch
       - name: Clean up
+        env:
+          TAG: ${{ steps.read-tag-name.outputs.TAG }}
         run: |
           git fetch origin
-          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push --delete origin "$TAG"
           git push origin --delete releases/next-release


### PR DESCRIPTION
## What

Proactively hardening our GitHub Actions workflows with zizmor, ahead of the AppSec script-injection tickets we've been getting on the other DevEx repos. Same approach we've already merged for `aws-dotnet-ai`, `aws-lambda-dotnet`, etc.

## Changes

- Move untrusted `${{ }}` values into `env:` vars so they can't run as shell
  code (the script-injection fix)
- Pin all actions to commit SHAs — no version bumps
- Set top-level `permissions: {}` with minimal per-job grants
- Add concurrency groups and job names
- Pin the semgrep container image by digest

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement